### PR TITLE
Update rspec syntax, fix broken specs

### DIFF
--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -245,6 +245,12 @@ describe CdnetworksClient do
     end
 
     context "getting a list of PADs" do
+      before do
+        stub_request(:post, "#{@url}/purge/rest/padList").
+          with(:body => {"pass"=>"secret", "user"=>"user@user.com"}).
+          to_return(:status => 200, :body => "", :headers => {})
+      end
+
       it "calls the list method" do
         @cdn_api.pad_list
 
@@ -259,6 +265,11 @@ describe CdnetworksClient do
     end
 
     context "get the status of a purge" do
+      before do
+        stub_request(:post, "https://openapi.us.cdnetworks.com/purge/rest/status").
+          to_return(status: 200, body: "", headers: {})
+      end
+
       it "calls the status method" do
         @cdn_api.status
 

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -21,25 +21,25 @@ describe CdnetworksClient do
     it "calls the list method of the cdnetworks api" do
       @cdn_api.list
 
-      a_request(:post, "#{@url}/config/rest/pan/site/list").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/list").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
     end
 
     it "includes options passed as a hash" do
       @cdn_api.list(:prod => true)
 
-      a_request(:post, "#{@url}/config/rest/pan/site/list").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/list").
         with(:body    => 'prod=true&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
     end
   end
 
@@ -52,25 +52,25 @@ describe CdnetworksClient do
     it "calls the view method of the cdnetworks api" do
       @cdn_api.view
 
-      a_request(:post, "#{@url}/config/rest/pan/site/view").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/view").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
 
     it "includes options passed as a hash" do
       @cdn_api.view(:pad => "cache.foo.com")
 
-      a_request(:post, "#{@url}/config/rest/pan/site/view").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/view").
         with(:body    => 'pad=cache.foo.com&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
 
   end
@@ -84,25 +84,25 @@ describe CdnetworksClient do
     it "calls the add method of the cdnetworks api" do
       @cdn_api.add
 
-      a_request(:post, "#{@url}/config/rest/pan/site/add").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/add").
       with(:body    => 'user=user%40user.com&pass=secret',
            :headers => {
                          'Accept'      =>'*/*',
                          'Content-Type'=>'application/x-www-form-urlencoded',
-                         'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                         'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
 
     it "includes options passed as a hash" do
       @cdn_api.add(:pad => "cache.foo.com", :origin => "neworigin.foo.com")
 
-      a_request(:post, "#{@url}/config/rest/pan/site/add").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/add").
         with(:body    => 'pad=cache.foo.com&origin=neworigin.foo.com&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
   end
 
@@ -115,25 +115,25 @@ describe CdnetworksClient do
     it "calls the edit method of the cdnetworks api" do
       @cdn_api.edit
 
-      a_request(:post, "#{@url}/config/rest/pan/site/edit").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/edit").
       with(:body    => 'user=user%40user.com&pass=secret',
            :headers => {
                          'Accept'      =>'*/*',
                          'Content-Type'=>'application/x-www-form-urlencoded',
-                         'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                         'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
 
     it "includes the options passed as a hash" do
       @cdn_api.edit(:pad => "cache.foo.com", :honor_byte_range => "1")
 
-      a_request(:post, "#{@url}/config/rest/pan/site/edit").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/edit").
       with(:body    => 'pad=cache.foo.com&honor_byte_range=1&user=user%40user.com&pass=secret',
            :headers => {
                          'Accept'      =>'*/*',
                          'Content-Type'=>'application/x-www-form-urlencoded',
-                         'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                         'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
   end
 
@@ -147,37 +147,37 @@ describe CdnetworksClient do
       it "calls the purge method of the cdnetworks api" do
         @cdn_api.execute_cache_purge
 
-        a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
+        expect(a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
         with(:body    => 'userId=user%40user.com&password=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "includes the options passed as a hash" do
         @cdn_api.execute_cache_purge(:purgeUriList => "cdn.example.com")
 
-        a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
+        expect(a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
         with(:body    => 'purgeUriList=cdn.example.com&userId=user%40user.com&password=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "handles options passed as an array" do
         @cdn_api.execute_cache_purge(:purgeUriList => ["cdn.example.com", "pad.foo.com"])
 
-        a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
+        expect(a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
         with(:body    => 'purgeUriList=cdn.example.com&purgeUriList=pad.foo.com&userId=user%40user.com&password=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
 
@@ -190,13 +190,13 @@ describe CdnetworksClient do
       it "calls the cache domain list method of the cdnetworks api" do
         @cdn_api.get_cache_domain_list
 
-        a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/getCacheDomainList").
+        expect(a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/getCacheDomainList").
         with(:body    => 'userId=user%40user.com&password=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
   end
@@ -211,36 +211,36 @@ describe CdnetworksClient do
       it "calls the purge method" do
         @cdn_api.do_purge
 
-        a_request(:post, "#{@url}/purge/rest/doPurge").
+        expect(a_request(:post, "#{@url}/purge/rest/doPurge").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "handles options passed as a hash" do
         @cdn_api.do_purge(:pad => "cdn.example.com", :type => "all")
 
-        a_request(:post, "#{@url}/purge/rest/doPurge").
+        expect(a_request(:post, "#{@url}/purge/rest/doPurge").
         with(:body    => 'pad=cdn.example.com&type=all&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "handles options passed as an array" do
         @cdn_api.do_purge(:path => ["/images/one.jpg", "/images/two.jpg"])
-        a_request(:post, "#{@url}/purge/rest/doPurge").
+        expect(a_request(:post, "#{@url}/purge/rest/doPurge").
         with(:body    => 'path=%2Fimages%2Fone.jpg&path=%2Fimages%2Ftwo.jpg&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
 
@@ -248,13 +248,13 @@ describe CdnetworksClient do
       it "calls the list method" do
         @cdn_api.pad_list
 
-        a_request(:post, "#{@url}/purge/rest/padList").
+        expect(a_request(:post, "#{@url}/purge/rest/padList").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
 
@@ -262,25 +262,25 @@ describe CdnetworksClient do
       it "calls the status method" do
         @cdn_api.status
 
-        a_request(:post, "#{@url}/purge/rest/status").
+        expect(a_request(:post, "#{@url}/purge/rest/status").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "handles options passsed as a hash" do
         @cdn_api.status(pid: 1234)
 
-        a_request(:post, "#{@url}/purge/rest/status").
+        expect(a_request(:post, "#{@url}/purge/rest/status").
         with(:body    => 'pid=1234&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
   end
@@ -288,7 +288,7 @@ describe CdnetworksClient do
   context "locations" do
     it "uses the US access domain by default" do
       request = @cdn_api.compose_request("/some/path",{})
-      request.path.should include("openapi.us.cdnetworks.com")
+      expect(request.path).to include("openapi.us.cdnetworks.com")
     end
 
     it "uses the Korean access domain when specified" do
@@ -299,7 +299,7 @@ describe CdnetworksClient do
                    )
 
       request = korean_cdn.compose_request("/some/path",{})
-      request.path.should include("openapi.kr.cdnetworks.com")
+      expect(request.path).to include("openapi.kr.cdnetworks.com")
     end
 
     it "uses the Japanese access domain when specified" do
@@ -310,7 +310,7 @@ describe CdnetworksClient do
                    )
 
       request = japanese_cdn.compose_request("/some/path",{})
-      request.path.should include("openapi.jp.cdnetworks.com")
+      expect(request.path).to include("openapi.jp.cdnetworks.com")
     end
 
     it "uses the Chinese access domain when specified" do
@@ -321,7 +321,7 @@ describe CdnetworksClient do
                    )
 
       request = chinese_cdn.compose_request("/some/path",{})
-      request.path.should include("openapi.txnetworks.cn")
+      expect(request.path).to include("openapi.txnetworks.cn")
     end
   end
 
@@ -339,8 +339,8 @@ describe CdnetworksClient do
 
     it "returns an error" do
       error_result = @cdn_api.list
-      error_result.should include("An error has occurred")
-      error_result.should include("execution expired")
+      expect(error_result).to include("An error has occurred")
+      expect(error_result).to include("execution expired")
     end
   end
 


### PR DESCRIPTION
Updates all tests to use the `expect` syntax in favor of the deprecated `should` syntax.

Also fixes a few tests that were failing because their http calls were not properly stubbed.