### PR TITLE
Statistics bandwidth usage

### DIFF
--- a/lib/cdnetworks-client.rb
+++ b/lib/cdnetworks-client.rb
@@ -16,17 +16,18 @@ class CdnetworksClient
   include CachePurgeApi
   include CacheFlushOpenApi
   include StatisticsOpenApi
+  attr_accessor :user, :password, :location
 
   MAX_SESSION_RETRIES = 2
 
   def initialize(credentials={})
-    @user       = credentials[:user]
-    @password   = credentials[:pass]
-    @location   = credentials[:location]
+    self.user       = credentials[:user]
+    self.password   = credentials[:pass]
+    self.location   = credentials[:location]
   end
 
   def compose_request(path,options)
-    request = Net::HTTP::Post.new("#{base_url(@location)}#{path}")
+    request = Net::HTTP::Post.new("#{base_url(location)}#{path}")
     request.set_form_data(options)
     request
   end
@@ -34,28 +35,24 @@ class CdnetworksClient
   def call(path,options,session_retries=0)
     response = http.request(compose_request(path,options))
 
-    if @location == "Beta"
+    if location == "Beta"
       process_beta_response(path, options, response, session_retries)
     else
       response_hash = { code: response.code, body: response.body }
     end
   end
 
-  def location
-    @location
-  end
-
   private
 
-  def base_url(location=nil)
+  def base_url(loc=nil)
     case
-    when location == "Korea"
+    when loc == "Korea"
       "https://openapi.kr.cdnetworks.com"
-    when location == "Japan"
+    when loc == "Japan"
       "https://openapi.jp.cdnetworks.com"
-    when location == "China"
+    when loc == "China"
       "https://openapi.txnetworks.cn"
-    when location == "Beta"
+    when loc == "Beta"
       "https://openapi-beta.cdnetworks.com"
     else
       "https://openapi.us.cdnetworks.com"
@@ -89,7 +86,7 @@ class CdnetworksClient
   end
 
   def http
-    uri = URI.parse(base_url(@location))
+    uri = URI.parse(base_url(location))
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true

--- a/lib/cdnetworks-client.rb
+++ b/lib/cdnetworks-client.rb
@@ -1,12 +1,19 @@
+require "json"
+
 require "cdnetworks-client/version"
 require "cdnetworks-client/cache_purge_api"
 require "cdnetworks-client/config_open_api"
 require "cdnetworks-client/cache_flush_open_api"
+require "cdnetworks-client/open_api_error"
+require "cdnetworks-client/auth_open_api"
+require "cdnetworks-client/open_api_keys"
+require "cdnetworks-client/statistics_open_api"
 
 class CdnetworksClient
   include ConfigOpenApi
   include CachePurgeApi
   include CacheFlushOpenApi
+  include StatisticsOpenApi
 
 
   def initialize(credentials={})

--- a/lib/cdnetworks-client.rb
+++ b/lib/cdnetworks-client.rb
@@ -1,5 +1,7 @@
 require "json"
 
+require_relative "patches"
+
 require "cdnetworks-client/version"
 require "cdnetworks-client/cache_purge_api"
 require "cdnetworks-client/config_open_api"

--- a/lib/cdnetworks-client.rb
+++ b/lib/cdnetworks-client.rb
@@ -87,7 +87,8 @@ class CdnetworksClient
       begin
         parsed = JSON.parse(response.body.to_s)
         if parsed.values.first
-          parsed.values.first['returnCode'] == 102
+          parsed.values.first['returnCode'] == 102 ||
+            parsed.values.first['resultCode'] == 102
         else
           false
         end

--- a/lib/cdnetworks-client.rb
+++ b/lib/cdnetworks-client.rb
@@ -78,8 +78,8 @@ class CdnetworksClient
 
       result_code = data.values.first['resultCode'] || data.values.first['returnCode']
 
-      if !%w{0 200}.include?(result_code.to_s)
-        OpenApiError::ErrorHandler.handle_error_response(result_code, body)
+      if !%w{0 200 404}.include?(result_code.to_s)
+        OpenApiError::ErrorHandler.handle_error_response(result_code, response.body)
       else
         {code: result_code, body: data}
       end

--- a/lib/cdnetworks-client.rb
+++ b/lib/cdnetworks-client.rb
@@ -47,13 +47,15 @@ class CdnetworksClient
       "https://openapi.jp.cdnetworks.com"
     when location == "China"
       "https://openapi.txnetworks.cn"
+    when location == "Beta"
+      "https://openapi-beta.cdnetworks.com"
     else
       "https://openapi.us.cdnetworks.com"
     end
   end
 
   def http
-    uri = URI.parse(base_url)
+    uri = URI.parse(base_url(@location))
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true

--- a/lib/cdnetworks-client.rb
+++ b/lib/cdnetworks-client.rb
@@ -47,6 +47,10 @@ class CdnetworksClient
     response_hash = { code: response.code, body: response.body }
   end
 
+  def location
+    @location
+  end
+
   private
 
   def base_url(location=nil)

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -1,5 +1,5 @@
 module AuthOpenApi
-  BASE_URL = "https://openapi.cdnetworks.com"
+  BASE_URL = "https://openapi.us.cdnetworks.com"
   LOGIN_URL = "#{BASE_URL}/api/rest/login"
   LOGOUT_URL = "#{BASE_URL}/api/rest/logout"
 
@@ -23,10 +23,7 @@ module AuthOpenApi
         pass: @pass,
         output: "json"
       }
-      request = Net::HTTP::Post.new(LOGIN_URL)
-      request.set_form_data(params)
-
-      response = http.request(request)
+      response = Net::HTTP.post_form(URI(LOGIN_URL), params)
 
       if error = OpenApiError::ERROR_CODES[response.code]
         raise_handled_error(response.code, error)

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -55,7 +55,7 @@ module AuthOpenApi
       elsif %w{0 200}.include?(response.code.to_s)
 
         data = JSON.parse(response.body)
-        code = data.fetch("#{type}Response",{})['returnCode']
+        code = data.fetch("#{type}Response",{})['resultCode']
 
         if error = OpenApiError::ERROR_CODES[code.to_s]
           raise_handled_error(code, error)

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -53,9 +53,8 @@ module AuthOpenApi
       if error = OpenApiError::ERROR_CODES[response.code.to_s]
         raise_handled_error(response.code, error)
       elsif %w{0 200}.include?(response.code.to_s)
-
         data = JSON.parse(response.body)
-        code = data.fetch("#{type}Response",{})['resultCode']
+        code = data.fetch("#{type}Response",{})['resultCode'] || data.fetch("#{type}Response",{})['returnCode']
 
         if error = OpenApiError::ERROR_CODES[code.to_s]
           raise_handled_error(code, error)

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -88,6 +88,12 @@ module AuthOpenApi
       @auth_session = AuthSession.new(@user, @password, base_url(@location))
     end
 
-    @auth_session.session
+    session = Array.wrap(@auth_session.session)[keynum]
+
+    if session.is_a?(Hash)
+      session['sessionToken']
+    else
+      nil
+    end
   end
 end

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -1,14 +1,14 @@
 module AuthOpenApi
-  BASE_URL = "https://openapi-beta.cdnetworks.com"
-  LOGIN_URL = "#{BASE_URL}/api/rest/login"
-  LOGOUT_URL = "#{BASE_URL}/api/rest/logout"
+  LOGIN_URL = "/api/rest/login"
+  LOGOUT_URL = "/api/rest/logout"
 
   class AuthSession
     def raise_handled_error(code, desc)
       raise "Auth error: #{code} - #{desc}"
     end
 
-    def initialize(user, pass)
+    def initialize(user, pass, base_url)
+      @base_url = base_url
       @user = user
       @pass = pass
     end
@@ -23,7 +23,7 @@ module AuthOpenApi
         pass: @pass,
         output: "json"
       }
-      response = Net::HTTP.post_form(URI(LOGIN_URL), params)
+      response = Net::HTTP.post_form(URI("#{@base_url}#{LOGIN_URL}"), params)
 
       if error = OpenApiError::ERROR_CODES[response.code]
         raise_handled_error(response.code, error)
@@ -47,7 +47,7 @@ module AuthOpenApi
         pass: @pass,
         output: "json"
       }
-      request = Net::HTTP::Post.new(LOGIN_URL)
+      request = Net::HTTP::Post.new("#{@base_url}#{LOGIN_URL}")
       request.set_form_data(params)
 
       response = http.request(request)
@@ -74,6 +74,6 @@ module AuthOpenApi
   end
 
   def get_session
-    @auth_session ||= AuthSession.new(@user, @password).session
+    @auth_session ||= AuthSession.new(@user, @password, base_url(@location)).session
   end
 end

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -7,10 +7,10 @@ module AuthOpenApi
       raise OpenApiError::ApiError.new("Auth error: #{code} - #{desc}")
     end
 
-    def initialize(user, pass, base_url)
-      @base_url = base_url
+    def initialize(user, pass, client)
       @user = user
       @pass = pass
+      @client = client
     end
 
     def session
@@ -23,7 +23,9 @@ module AuthOpenApi
         pass: @pass,
         output: "json"
       }
-      handle_auth_response 'login', post_data("#{@base_url}#{LOGIN_URL}", params)
+      resp = @client.call(LOGIN_URL, params)
+
+      resp[:body]['loginResponse']['session']
     end
 
     def logout
@@ -32,48 +34,15 @@ module AuthOpenApi
         pass: @pass,
         output: "json"
       }
-      response = post_data("#{@base_url}#{LOGOUT_URL}", params)
 
-      handle_auth_response('logout', response)
-    end
-
-    def post_data(path, params)
-      uri = URI(path)
-      Net::HTTP.start(uri.host, uri.port,
-                                 :use_ssl => uri.scheme == 'https') do |http|
-
-        request = Net::HTTP::Post.new uri.to_s
-        request.set_form_data(params)
-
-        http.request request # Net::HTTPResponse object
-      end
-    end
-
-    def handle_auth_response(type, response)
-      if error = OpenApiError::ERROR_CODES[response.code.to_s]
-        raise_handled_error(response.code, error)
-      elsif %w{0 200}.include?(response.code.to_s)
-        data = JSON.parse(response.body)
-        code = data.fetch("#{type}Response",{})['resultCode'] || data.fetch("#{type}Response",{})['returnCode']
-
-        if error = OpenApiError::ERROR_CODES[code.to_s]
-          raise_handled_error(code, error)
-        else
-          data["#{type}Response"]['session']
-        end
-      else
-        raise OpenApiError::ApiError.new("Unknown Auth response: #{response.code}\n#{response.body}")
-      end
-    end
-
-    def expired?
-      raise "not implemented"
+      resp = @client.call(LOGOUT_URL, params)
+      resp[:body]['logoutResponse']
     end
   end
 
   def get_session_token(reset_session = false, keynum = 0)
     if !@auth_session || reset_session
-      @auth_session = AuthSession.new(@user, @password, base_url(@location))
+      @auth_session = AuthSession.new(@user, @password, self)
     end
 
     session = Array.wrap(@auth_session.session)[keynum]

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -26,7 +26,7 @@ module AuthOpenApi
       uri = URI("#{@base_url}#{LOGIN_URL}")
 
       response = Net::HTTP.start(uri.host, uri.port,
-                      :use_ssl => uri.scheme == 'https') do |http|
+                                 :use_ssl => uri.scheme == 'https') do |http|
 
         request = Net::HTTP::Post.new uri.to_s
         request.set_form_data(params)
@@ -83,7 +83,7 @@ module AuthOpenApi
     end
   end
 
-  def get_session(reset_session = false)
+  def get_session_token(reset_session = false, keynum = 0)
     if !@auth_session || reset_session
       @auth_session = AuthSession.new(@user, @password, base_url(@location))
     end

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -23,7 +23,15 @@ module AuthOpenApi
         pass: @pass,
         output: "json"
       }
-      response = Net::HTTP.post_form(URI("#{@base_url}#{LOGIN_URL}"), params)
+      uri = URI("#{@base_url}#{LOGIN_URL}")
+
+      response = Net::HTTP.start(uri.host, uri.port,
+                      :use_ssl => uri.scheme == 'https') do |http|
+
+        request = Net::HTTP::Post.new uri.to_s
+
+        http.request request # Net::HTTPResponse object
+      end
 
       if error = OpenApiError::ERROR_CODES[response.code.to_s]
         raise_handled_error(response.code, error)

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -1,5 +1,5 @@
 module AuthOpenApi
-  BASE_URL = "https://openapi.us.cdnetworks.com"
+  BASE_URL = "https://openapi-beta.cdnetworks.com"
   LOGIN_URL = "#{BASE_URL}/api/rest/login"
   LOGOUT_URL = "#{BASE_URL}/api/rest/logout"
 
@@ -73,7 +73,7 @@ module AuthOpenApi
     end
   end
 
-  def get_session(user, pass)
-    @auth_session ||= AuthSession.new(user, pass).session
+  def get_session
+    @auth_session ||= AuthSession.new(@user, @password).session
   end
 end

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -29,6 +29,7 @@ module AuthOpenApi
                       :use_ssl => uri.scheme == 'https') do |http|
 
         request = Net::HTTP::Post.new uri.to_s
+        request.set_form_data(params)
 
         http.request request # Net::HTTPResponse object
       end

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -73,7 +73,11 @@ module AuthOpenApi
     end
   end
 
-  def get_session
-    @auth_session ||= AuthSession.new(@user, @password, base_url(@location)).session
+  def get_session(reset = false)
+    if !@auth_session || reset
+      @auth_session = AuthSession.new(@user, @password, base_url(@location))
+    end
+
+    @auth_session.session
   end
 end

--- a/lib/cdnetworks-client/auth_open_api.rb
+++ b/lib/cdnetworks-client/auth_open_api.rb
@@ -1,0 +1,52 @@
+module AuthOpenApi
+  LOGIN_URL = "https://openapi.cdnetworks.com/api/rest/login"
+
+  class AuthSession
+    def raise_handled_error(code, desc)
+      raise "Auth error: #{code} - #{desc}"
+    end
+
+    def initialize(user, pass)
+      @user = user
+      @pass = pass
+    end
+
+    def login
+      params = {
+        user: @user,
+        pass: @pass,
+        output: "json"
+      }
+      request = Net::HTTP::Post.new(LOGIN_URL)
+      request.set_form_data(params)
+
+      response = http.request(request)
+
+      if error = OpenApiError::ERROR_CODES[response.code]
+        raise_handled_error(response.code, error)
+      elsif %w{0 200}.include?(response.code)
+        data = JSON.parse(response.body)
+        code = data.fetch('loginResponse',{})['resultCode']
+        if error = OpenApiError::ERROR_CODES[code.to_s]
+          raise_handled_error(code, error)
+        else
+          data['loginResponse']['session']
+        end
+      else
+        raise "Unknown Auth response: #{response.code}\n#{response.body}"
+      end
+    end
+
+    def logout
+      raise "not implemented"
+    end
+
+    def expired?
+      raise "not implemented"
+    end
+  end
+
+  def get_session(user, pass)
+    @auth_session ||= AuthSession.new(user, pass).login
+  end
+end

--- a/lib/cdnetworks-client/config_open_api.rb
+++ b/lib/cdnetworks-client/config_open_api.rb
@@ -1,4 +1,9 @@
 module ConfigOpenApi
+  def list_new(options={})
+    session_token = get_session_token
+    keys = get_api_key_list(session_token)
+    keys.map{|d| d['serviceName']}
+  end
 
   def list(options={})
     call(config_open_path("list"),add_config_credentials(options))

--- a/lib/cdnetworks-client/config_open_api.rb
+++ b/lib/cdnetworks-client/config_open_api.rb
@@ -2,11 +2,21 @@ module ConfigOpenApi
   def list(options={})
     if location == "Beta"
       session_token = get_session_token
-      # keys = get_api_key_list(session_token)
-
-      params = { sessionToken: session_token, apiKey: "SERVICECATEGORY_CA" }
+      keys = get_api_key_list(session_token)
+      api_key = keys.find{|k| k["type"] == 0}["apiKey"]
+      params = { sessionToken: session_token, apiKey: api_key }
       pad_path = "/api/rest/pan/site/list"
-      call(pad_path, params)
+      response = call(pad_path, params.merge(options))
+      if response[:code].to_s == "200"
+        data = JSON.parse(response[:body])
+        result_code = data.fetch("PadConfigResponse",{})["resultCode"]
+
+        if OpenApiError::ERROR_CODES.keys.include?(result_code.to_s)
+          OpenApiError::handle_error_response(response[:code], response[:body])
+        else
+          data["PadConfigResponse"]["data"]["data"]
+        end
+      end
     else
       call(config_open_path("list"),add_config_credentials(options))
     end

--- a/lib/cdnetworks-client/config_open_api.rb
+++ b/lib/cdnetworks-client/config_open_api.rb
@@ -11,10 +11,10 @@ module ConfigOpenApi
         data = JSON.parse(response[:body])
         result_code = data.fetch("PadConfigResponse",{})["resultCode"]
 
-        if OpenApiError::ERROR_CODES.keys.include?(result_code.to_s)
-          OpenApiError::handle_error_response(response[:code], response[:body])
-        else
+        if %w{0 200}.include? result_code.to_s
           data["PadConfigResponse"]["data"]["data"]
+        else
+          OpenApiError::ErrorHandler.handle_error_response(result_code, body)
         end
       end
     else

--- a/lib/cdnetworks-client/config_open_api.rb
+++ b/lib/cdnetworks-client/config_open_api.rb
@@ -2,8 +2,11 @@ module ConfigOpenApi
   def list(options={})
     if location == "Beta"
       session_token = get_session_token
-      keys = get_api_key_list(session_token)
-      keys.map{|d| d['serviceName']}
+      # keys = get_api_key_list(session_token)
+
+      params = { sessionToken: session_token, apiKey: "SERVICECATEGORY_CA" }
+      pad_path = "/api/rest/pan/site/list"
+      call(pad_path, params)
     else
       call(config_open_path("list"),add_config_credentials(options))
     end

--- a/lib/cdnetworks-client/config_open_api.rb
+++ b/lib/cdnetworks-client/config_open_api.rb
@@ -1,12 +1,12 @@
 module ConfigOpenApi
-  def list_new(options={})
-    session_token = get_session_token
-    keys = get_api_key_list(session_token)
-    keys.map{|d| d['serviceName']}
-  end
-
   def list(options={})
-    call(config_open_path("list"),add_config_credentials(options))
+    if location == "Beta"
+      session_token = get_session_token
+      keys = get_api_key_list(session_token)
+      keys.map{|d| d['serviceName']}
+    else
+      call(config_open_path("list"),add_config_credentials(options))
+    end
   end
 
   def view(options={})

--- a/lib/cdnetworks-client/open_api_error.rb
+++ b/lib/cdnetworks-client/open_api_error.rb
@@ -12,12 +12,20 @@ module OpenApiError
     "999" => "Temporary error"
   }
 
+  class ApiError < StandardError
+
+  end
+
+  class CriticalApiError < StandardError
+
+  end
+
   class ErrorHandler
     def self.handle_error_response(code, body)
       if desc = ERROR_CODES[code.to_s]
-        raise "Open API Error #{code}: #{desc}"
+        raise ApiError.new("Open API Error #{code}: #{desc}")
       else
-        raise "Unknown Open API Response Code #{code} (body: #{body})"
+        raise ApiError.new("Unknown Open API Response Code #{code} (body: #{body})")
       end
     end
   end

--- a/lib/cdnetworks-client/open_api_error.rb
+++ b/lib/cdnetworks-client/open_api_error.rb
@@ -8,7 +8,6 @@ module OpenApiError
     "203" => "Inaccessible service (Setting can be modified via Customer Portal)",
     "204" => "Inaccessible Request (See Table-1. The Scope of CDNetworks Statistics Open API)",
     "301" => "Unregistered API key (Registration information is provided in Customer Portal)",
-    "404" => "There is no data.",
     "999" => "Temporary error"
   }
 

--- a/lib/cdnetworks-client/open_api_error.rb
+++ b/lib/cdnetworks-client/open_api_error.rb
@@ -1,0 +1,14 @@
+module OpenApiError
+  ERROR_CODES = {
+    "101" => "User login information error",
+    "102" => "Invalid session",
+    "103" => "Logout failure",
+    "104" => "Input parameter error (no entry is made or invalid value)",
+    "202" => "Inaccessible menu (Setting can be modified via Customer Portal)",
+    "203" => "Inaccessible service (Setting can be modified via Customer Portal)",
+    "204" => "Inaccessible Request (See Table-1. The Scope of CDNetworks Statistics Open API)",
+    "301" => "Unregistered API key (Registration information is provided in Customer Portal)",
+    "404" => "There is no data.",
+    "999" => "Temporary error"
+  }
+end

--- a/lib/cdnetworks-client/open_api_error.rb
+++ b/lib/cdnetworks-client/open_api_error.rb
@@ -11,4 +11,14 @@ module OpenApiError
     "404" => "There is no data.",
     "999" => "Temporary error"
   }
+
+  class ErrorHandler
+    def self.handle_error_response(code, body)
+      if desc = ERROR_CODES[code.to_s]
+        raise "Open API Error #{code}: #{desc}"
+      else
+        raise "Unknown Open API Response Code #{code} (body: #{body})"
+      end
+    end
+  end
 end

--- a/lib/cdnetworks-client/open_api_keys.rb
+++ b/lib/cdnetworks-client/open_api_keys.rb
@@ -9,7 +9,7 @@ module OpenApiKeys
     uri = URI("#{base_url(@location)}/#{GET_KEY_PATH}")
     uri.query = URI.encode_www_form(params)
 
-    response_handler = -> (response) do
+    response_handler = lambda do |response|
       if response[:code] == "200"
         body = response[:body]
         parsed = JSON.parse(body)

--- a/lib/cdnetworks-client/open_api_keys.rb
+++ b/lib/cdnetworks-client/open_api_keys.rb
@@ -9,24 +9,9 @@ module OpenApiKeys
     uri = URI("#{base_url(@location)}/#{GET_KEY_PATH}")
     uri.query = URI.encode_www_form(params)
 
-    response_handler = lambda do |response|
-      if response[:code] == "200"
-        body = response[:body]
-        parsed = JSON.parse(body)
-        return_code = parsed['apiKeyInfo']['returnCode']
-
-        unless %w{0 200}.include? return_code.to_s
-          OpenApiError::ErrorHandler.handle_error_response(return_code, body)
-        end
-
-        parsed['apiKeyInfo']['apiKeyInfoItem']
-      else
-        OpenApiError::ErrorHandler.handle_error_response(response[:code], body)
-      end
-    end
-
     response = call(GET_KEY_PATH, params)
-    return response_handler.call(response)
+
+    response[:body]['apiKeyInfo']['apiKeyInfoItem']
   end
 
   def get_api_key(session_token, service_name)

--- a/lib/cdnetworks-client/open_api_keys.rb
+++ b/lib/cdnetworks-client/open_api_keys.rb
@@ -1,0 +1,5 @@
+module OpenApiKeys
+  def get_api_key(session_token)
+    raise "not implemented"
+  end
+end

--- a/lib/cdnetworks-client/open_api_keys.rb
+++ b/lib/cdnetworks-client/open_api_keys.rb
@@ -1,7 +1,7 @@
 module OpenApiKeys
   GET_KEY_PATH = "/api/rest/getApiKeyList"
 
-  def get_api_key(session_token, service_name)
+  def get_api_key_list(session_token)
     params = {
       output: "json",
       sessionToken: session_token
@@ -19,15 +19,7 @@ module OpenApiKeys
           OpenApiError::ErrorHandler.handle_error_response(return_code, body)
         end
 
-        key_for_service = (parsed['apiKeyInfo']['apiKeyInfoItem'] || []).find do |service|
-          service['serviceName'] == service_name
-        end
-
-        unless key_for_service
-          raise "No key found for #{service_name}"
-        end
-
-        return key_for_service['apiKey']
+        parsed['apiKeyInfo']['apiKeyInfoItem']
       else
         OpenApiError::ErrorHandler.handle_error_response(response[:code], body)
       end
@@ -35,5 +27,18 @@ module OpenApiKeys
 
     response = call(GET_KEY_PATH, params)
     return response_handler.call(response)
+  end
+
+  def get_api_key(session_token, service_name)
+
+    key_for_service = (get_api_key_list(session_token) || []).find do |service|
+      service['serviceName'] == service_name
+    end
+
+    unless key_for_service
+      raise "No key found for #{service_name}"
+    end
+
+    return key_for_service['apiKey']
   end
 end

--- a/lib/cdnetworks-client/open_api_keys.rb
+++ b/lib/cdnetworks-client/open_api_keys.rb
@@ -1,5 +1,29 @@
 module OpenApiKeys
+  BASE_URL = "https://openapi.us.cdnetworks.com"
+  GET_KEY_URL = "#{BASE_URL}/api/rest/getApiKeyList"
+
   def get_api_key(session_token)
-    raise "not implemented"
+    params = {
+      session_token: session_token,
+      output: "json"
+    }
+    uri = URI(GET_KEY_URL)
+    uri.query = URI.encode_www_form(params)
+
+    Net::HTTP.get_response(uri) do |response|
+      if response.code == "200"
+        body = response.read_body
+        parsed = JSON.parse(body)
+        return_code = parsed['apiKeyListResponse']['resultCode']
+
+        unless %w{0 200}.include? return_code.to_s
+          OpenApiError::ErrorHandler.handle_error_response(return_code, body)
+        end
+
+        return parsed['apiKeyListResponse']['apiKeyInformation'][2]
+      else
+        OpenApiError::ErrorHandler.handle_error_response(response.code, body)
+      end
+    end
   end
 end

--- a/lib/cdnetworks-client/open_api_keys.rb
+++ b/lib/cdnetworks-client/open_api_keys.rb
@@ -1,10 +1,10 @@
 module OpenApiKeys
-  BASE_URL = "https://openapi.us.cdnetworks.com"
+  BASE_URL = "https://openapi-beta.cdnetworks.com"
   GET_KEY_URL = "#{BASE_URL}/api/rest/getApiKeyList"
 
-  def get_api_key(session_token)
+  def get_api_key(session_token, service_name)
     params = {
-      session_token: session_token,
+      sessionToken: session_token,
       output: "json"
     }
     uri = URI(GET_KEY_URL)
@@ -20,7 +20,15 @@ module OpenApiKeys
           OpenApiError::ErrorHandler.handle_error_response(return_code, body)
         end
 
-        return parsed['apiKeyInfo']['apiKeyInfoItem']
+        key_for_service = (parsed['apiKeyInfo']['apiKeyInfoItem'] || []).find do |service|
+          service['serviceName'] == service_name
+        end
+
+        unless key_for_service
+          raise "No key found for #{service_name}"
+        end
+
+        return key_for_service['apiKey']
       else
         OpenApiError::ErrorHandler.handle_error_response(response.code, body)
       end

--- a/lib/cdnetworks-client/open_api_keys.rb
+++ b/lib/cdnetworks-client/open_api_keys.rb
@@ -14,13 +14,13 @@ module OpenApiKeys
       if response.code == "200"
         body = response.read_body
         parsed = JSON.parse(body)
-        return_code = parsed['apiKeyListResponse']['resultCode']
+        return_code = parsed['apiKeyInfo']['returnCode']
 
         unless %w{0 200}.include? return_code.to_s
           OpenApiError::ErrorHandler.handle_error_response(return_code, body)
         end
 
-        return parsed['apiKeyListResponse']['apiKeyInformation'][2]
+        return parsed['apiKeyInfo']['apiKeyInfoItem']
       else
         OpenApiError::ErrorHandler.handle_error_response(response.code, body)
       end

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -2,7 +2,7 @@ module StatisticsOpenApi
   include AuthOpenApi
   include OpenApiKeys
 
-  BANDWIDTH_PATH = "api/rest/traffic/edge"
+  BANDWIDTH_PATH = "/api/rest/traffic/edge"
 
   class StatsHelper
     def self.handle_error_response(code, body)
@@ -14,11 +14,16 @@ module StatisticsOpenApi
         parsed = JSON.parse(resp[:body])
         return_code = parsed['trafficResponse']['returnCode'].to_s
 
-        unless %w{0 200}.include? return_code
+        unless %w{0 200 404}.include? return_code
           OpenApiError::ErrorHandler.handle_error_response(return_code, resp[:body])
         end
 
-        parsed['trafficResponse']['trafficItem'][0]['bandwidth']
+        if return_code == "404"
+          nil
+        else
+          parsed['trafficResponse']['trafficItem'][0]['bandwidth']
+        end
+
       else
         OpenApiError::ErrorHandler.handle_error_response(resp[:code], resp[:body])
       end
@@ -33,8 +38,8 @@ module StatisticsOpenApi
     opts = {
       sessionToken: session.first['sessionToken'],
       apiKey: api_key,
-      fromDate: from,
-      toDate: to,
+      fromDate: from.strftime("%Y%m%d"),
+      toDate: to.strftime("%Y%m%d"),
       timeInterval: time_interval,
       output: "json"
     }

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -31,12 +31,12 @@ module StatisticsOpenApi
   end
 
   def bandwidth_usage(service_name, from, to, time_interval = 2)
-    session = get_session
+    session_token = get_session_token
 
-    api_key = get_api_key(session.first["sessionToken"], service_name)
+    api_key = get_api_key(session_token, service_name)
 
     opts = {
-      sessionToken: session.first['sessionToken'],
+      sessionToken: session_token,
       apiKey: api_key,
       fromDate: from.strftime("%Y%m%d"),
       toDate: to.strftime("%Y%m%d"),

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -12,13 +12,13 @@ module StatisticsOpenApi
     def self.handle_response(resp)
       if resp[:code] == "200"
         parsed = JSON.parse(resp[:body])
-        return_code = parsed['edgeTrafficResponse']['returnCode'].to_s
+        return_code = parsed['trafficResponse']['returnCode'].to_s
 
         unless %w{0 200}.include? return_code
           OpenApiError::ErrorHandler.handle_error_response(return_code, resp[:body])
         end
 
-        parsed['edgeTrafficResponse']['trafficItem'][1]
+        parsed['trafficResponse']['trafficItem'][0]['bandwidth']
       else
         OpenApiError::ErrorHandler.handle_error_response(resp[:code], resp[:body])
       end
@@ -27,7 +27,7 @@ module StatisticsOpenApi
 
   def bandwidth_usage(from, to, time_interval = 2)
     session = get_session(@user, @password)
-    api_key = get_api_key(session.first)
+    api_key = get_api_key(session.first["sessionToken"])
 
     opts = {
       sessionToken: session.first, # == sessionToken. Should make this a has in auth module

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -1,0 +1,46 @@
+module StatisticsOpenApi
+  BANDWIDTH_PATH = "api/rest/traffic/edge"
+
+  class StatsHelper
+    def self.handle_response(resp)
+      if resp[:code] == "200"
+        JSON.parse(resp[:body])['bandwidth']
+      else
+        if desc = OpenApiError::ERROR_CODES[resp[:code]]
+          raise "Error #{resp[:code]}: #{desc}"
+        else
+          raise "Unexpected response #{resp[:code]}"
+        end
+      end
+    end
+  end
+
+  def bandwidth_usage
+    opts = {
+      sessionToken: "",
+      apiKey: "",
+      fromDate: "",
+      toDate: "",
+      timeInterval: "",
+      output: "json"
+    }
+
+    response = call(BANDWIDTH_PATH, opts)
+
+    StatsHelper.handle_response(response)
+
+    # response = @@bandwidth_use.lookup(
+    #   site_id,
+    #   @@sp.username,
+    #   @@sp.plaintext_password,
+    #   "1", # CL - Using 1 gives us stuff we want. using 2 gives us something else. What either means is beyond me.
+    #   start_time.strftime("%Y-%m-%d %H:%M:%S"),
+    #   end_time.strftime("%Y-%m-%d %H:%M:%S")# CL - These dates have to be in this exact format
+    # )
+
+    # # CL - If there is an error code, find out what it means
+    # raise error_to_string(response) if response.to_f < 0
+
+    # return response.to_f
+  end
+end

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -9,7 +9,7 @@ module StatisticsOpenApi
       raise "Error #{resp[:code]}: #{desc}"
     end
 
-    def self.handle_response(resp)
+    def self.handle_bandwidth_response(resp)
       if resp[:code] == "200"
         parsed = JSON.parse(resp[:body])
         return_code = parsed['trafficResponse']['returnCode'].to_s
@@ -46,6 +46,6 @@ module StatisticsOpenApi
 
     response = call(BANDWIDTH_PATH, opts)
 
-    StatsHelper.handle_response(response)
+    StatsHelper.handle_bandwidth_response(response)
   end
 end

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -25,12 +25,13 @@ module StatisticsOpenApi
     end
   end
 
-  def bandwidth_usage(from, to, time_interval = 2)
-    session = get_session(@user, @password)
-    api_key = get_api_key(session.first["sessionToken"])
+  def bandwidth_usage(service_name, from, to, time_interval = 2)
+    session = get_session
+
+    api_key = get_api_key(session.first["sessionToken"], service_name)
 
     opts = {
-      sessionToken: session.first, # == sessionToken. Should make this a has in auth module
+      sessionToken: session.first['sessionToken'],
       apiKey: api_key,
       fromDate: from,
       toDate: to,

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -1,4 +1,7 @@
 module StatisticsOpenApi
+  include AuthSession
+  include OpenApiKeys
+
   BANDWIDTH_PATH = "api/rest/traffic/edge"
 
   class StatsHelper
@@ -15,32 +18,21 @@ module StatisticsOpenApi
     end
   end
 
-  def bandwidth_usage
+  def bandwidth_usage(from, to, time_interval = 2)
+    session = get_session(@user, @password)
+    api_key = get_api_key(session.first)
+
     opts = {
-      sessionToken: "",
-      apiKey: "",
-      fromDate: "",
-      toDate: "",
-      timeInterval: "",
+      sessionToken: session.first, # == sessionToken. Should make this a has in auth module
+      apiKey: api_key,
+      fromDate: from,
+      toDate: to,
+      timeInterval: time_interval,
       output: "json"
     }
 
     response = call(BANDWIDTH_PATH, opts)
 
     StatsHelper.handle_response(response)
-
-    # response = @@bandwidth_use.lookup(
-    #   site_id,
-    #   @@sp.username,
-    #   @@sp.plaintext_password,
-    #   "1", # CL - Using 1 gives us stuff we want. using 2 gives us something else. What either means is beyond me.
-    #   start_time.strftime("%Y-%m-%d %H:%M:%S"),
-    #   end_time.strftime("%Y-%m-%d %H:%M:%S")# CL - These dates have to be in this exact format
-    # )
-
-    # # CL - If there is an error code, find out what it means
-    # raise error_to_string(response) if response.to_f < 0
-
-    # return response.to_f
   end
 end

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -4,32 +4,6 @@ module StatisticsOpenApi
 
   BANDWIDTH_PATH = "/api/rest/traffic/edge"
 
-  class StatsHelper
-    def self.handle_error_response(code, body)
-      raise "Error #{resp[:code]}: #{desc}"
-    end
-
-    def self.handle_bandwidth_response(resp)
-      if resp[:code] == "200"
-        parsed = JSON.parse(resp[:body])
-        return_code = parsed['trafficResponse']['returnCode'].to_s
-
-        unless %w{0 200 404}.include? return_code
-          OpenApiError::ErrorHandler.handle_error_response(return_code, resp[:body])
-        end
-
-        if return_code == "404"
-          nil
-        else
-          Array.wrap(parsed['trafficResponse']['trafficItem']).map{|i| i['dataTransferred']}.inject(&:+)
-        end
-
-      else
-        OpenApiError::ErrorHandler.handle_error_response(resp[:code], resp[:body])
-      end
-    end
-  end
-
   def bandwidth_usage(service_name, from, to, time_interval = 2)
     session_token = get_session_token
 
@@ -46,6 +20,10 @@ module StatisticsOpenApi
 
     response = call(BANDWIDTH_PATH, opts)
 
-    StatsHelper.handle_bandwidth_response(response)
+    if response[:code].to_s == "404"
+      nil
+    else
+      Array.wrap(response[:body]['trafficResponse']['trafficItem']).map{|i| i['dataTransferred']}.inject(&:+)
+    end
   end
 end

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -21,7 +21,11 @@ module StatisticsOpenApi
         if return_code == "404"
           nil
         else
-          parsed['trafficResponse']['trafficItem'][0]['bandwidth']
+          if parsed['trafficResponse']['trafficItem'].is_a? Hash
+            parsed['trafficResponse']['trafficItem']['dataTransferred']
+          else
+            parsed['trafficResponse']['trafficItem'].map{|i| i['dataTransferred']}.inject(&:+)
+          end
         end
 
       else

--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -21,11 +21,7 @@ module StatisticsOpenApi
         if return_code == "404"
           nil
         else
-          if parsed['trafficResponse']['trafficItem'].is_a? Hash
-            parsed['trafficResponse']['trafficItem']['dataTransferred']
-          else
-            parsed['trafficResponse']['trafficItem'].map{|i| i['dataTransferred']}.inject(&:+)
-          end
+          Array.wrap(parsed['trafficResponse']['trafficItem']).map{|i| i['dataTransferred']}.inject(&:+)
         end
 
       else

--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -1,0 +1,11 @@
+class Array
+  def self.wrap(object)
+    if object.nil?
+      []
+    elsif object.respond_to?(:to_ary)
+      object.to_ary || [object]
+    else
+      [object]
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -6,7 +6,7 @@ describe CdnetworksClient do
     @pass = ENV['CDN_PASS']
 
     unless @user && @pass
-      skip "either CDN_USER or CDN_PASS env var not set. exiting"
+      skip "either CDN_USER or CDN_PASS env var not set. skipping"
     end
 
     WebMock.allow_net_connect!
@@ -19,11 +19,16 @@ describe CdnetworksClient do
   end
 
   it 'gets a session' do
-    expect(@client.get_session.first['sessionToken']).not_to be_nil
+    expect(@client.get_session_token).not_to be_nil
   end
 
   skip 'gets bandwidth usage' do
     usage = @client.bandwidth_usage("service_name", Date.today - 2, Date.today - 1)
     expect(usage).to eq(0)
+  end
+
+  it 'lists domains for a session' do
+    domains = @client.list_new
+    expect(domains.length).to be > 0
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -28,7 +28,8 @@ describe CdnetworksClient do
   end
 
   it 'lists domains for a session' do
-    domains = @client.list_new
+    domains = @client.list
+
     expect(domains.length).to be > 0
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -27,9 +27,9 @@ describe CdnetworksClient do
     expect(usage).to eq(0)
   end
 
-  it 'lists domains for a session' do
-    domains = @client.list
+  it 'lists pads for a session' do
+    pads = @client.list
 
-    expect(domains.length).to be > 0
+    expect(pads.length).to be > 0
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -22,9 +22,11 @@ describe CdnetworksClient do
     expect(@client.get_session_token).not_to be_nil
   end
 
-  skip 'gets bandwidth usage' do
-    usage = @client.bandwidth_usage("service_name", Date.today - 2, Date.today - 1)
-    expect(usage).to eq(0)
+  it 'gets bandwidth usage' do
+    pad = ENV['CDN_PAD']
+    skip "must set CDN_PAD env var" unless pad
+    usage = @client.bandwidth_usage(pad, Date.today - 2, Date.today - 1)
+    expect(usage).to be > 0
   end
 
   it 'lists pads for a session' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,0 +1,29 @@
+require_relative 'spec_helper'
+
+describe CdnetworksClient do
+  before(:all) do
+    @user = ENV['CDN_USER']
+    @pass = ENV['CDN_PASS']
+
+    unless @user && @pass
+      skip "either CDN_USER or CDN_PASS env var not set. exiting"
+    end
+
+    WebMock.allow_net_connect!
+
+    @client = CdnetworksClient.new(user: @user, pass: @pass, location: "Beta")
+  end
+
+  after(:all) do
+    WebMock.disable_net_connect!
+  end
+
+  it 'gets a session' do
+    expect(@client.get_session.first['sessionToken']).not_to be_nil
+  end
+
+  skip 'gets bandwidth usage' do
+    usage = @client.bandwidth_usage("service_name", Date.today - 2, Date.today - 1)
+    expect(usage).to eq(0)
+  end
+end

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -245,6 +245,12 @@ describe CdnetworksClient do
     end
 
     context "getting a list of PADs" do
+      before do
+        stub_request(:post, "#{@url}/purge/rest/padList").
+          with(:body => {"pass"=>"secret", "user"=>"user@user.com"}).
+          to_return(:status => 200, :body => "", :headers => {})
+      end
+
       it "calls the list method" do
         @cdn_api.pad_list
 
@@ -259,6 +265,11 @@ describe CdnetworksClient do
     end
 
     context "get the status of a purge" do
+      before do
+        stub_request(:post, "https://openapi.us.cdnetworks.com/purge/rest/status").
+          to_return(status: 200, body: "", headers: {})
+      end
+
       it "calls the status method" do
         @cdn_api.status
 

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -349,9 +349,7 @@ describe CdnetworksClient do
     end
 
     it "returns an error" do
-      error_result = @cdn_api.list
-      expect(error_result).to include("An error has occurred")
-      expect(error_result).to include("execution expired")
+      expect { @cdn_api.list }.to raise_error(Timeout::Error)
     end
   end
 

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -399,12 +399,16 @@ describe CdnetworksClient do
 
     describe ConfigOpenApi do
       before { stub_pad_list(@fake_service) }
+
       it "fetches list using api key endpoint for OpenApiV2" do
         expect(@cdn_api.list.first["origin"]).to eq(@fake_service)
       end
     end
 
     describe AuthOpenApi do
+      it "raises error on failed login" do
+      end
+
       it "gets a session token" do
         session_token = @cdn_api.get_session_token
 

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -357,12 +357,18 @@ describe CdnetworksClient do
 
 
   describe AuthOpenApi do
-    before { @fake_token, _ = stub_auth_calls }
+    before { @fake_token, _, @fake_identifier = stub_auth_calls }
 
     it "gets a session token" do
       session = @cdn_api.get_session(@user, @password)
 
-      expect(session[0]).to eq(@fake_token)
+      expect(session[0]["sessionToken"]).to eq(@fake_token)
+    end
+
+    it "gets a service identifier" do
+      session = @cdn_api.get_session(@user, @password)
+
+      expect(session[0]["svcGroupIdentifier"]).to eq(@fake_identifier)
     end
   end
 
@@ -370,7 +376,7 @@ describe CdnetworksClient do
     before { @fake_token, @fake_key = stub_auth_calls }
 
     it "gets api keys" do
-      api_key = @cdn_api.get_api_key(@fake_token)
+      api_key = @cdn_api.get_api_key(@fake_token)[1]["apiKey"]
 
       expect(api_key).to eq(@fake_key)
     end

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -398,11 +398,9 @@ describe CdnetworksClient do
     end
 
     describe ConfigOpenApi do
+      before { stub_pad_list(@fake_service) }
       it "fetches list using api key endpoint for OpenApiV2" do
-        expect(@cdn_api.list).to include(@fake_service)
-
-        expect(a_request(:post, "#{@url}/api/rest/getApiKeyList")).
-                 to have_been_made
+        expect(@cdn_api.list.first["origin"]).to eq(@fake_service)
       end
     end
 

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -399,13 +399,13 @@ describe CdnetworksClient do
       before { @fake_token, _, @fake_identifier = stub_auth_calls }
 
       it "gets a session token" do
-        session = @cdn_api.get_session
+        session_token = @cdn_api.get_session_token
 
-        expect(session[0]["sessionToken"]).to eq(@fake_token)
+        expect(session_token).to eq(@fake_token)
       end
 
-      it "gets a service identifier" do
-        session = @cdn_api.get_session
+      skip "gets a service identifier" do
+        session = @cdn_api.get_session_token
 
         expect(session[0]["svcGroupIdentifier"]).to eq(@fake_identifier)
       end

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -363,6 +363,8 @@ describe CdnetworksClient do
                            )
 
       @url               = "https://openapi-beta.cdnetworks.com"
+
+      @fake_token, @fake_key, _, @fake_service = stub_auth_calls
     end
 
     context "Session Management" do
@@ -395,9 +397,16 @@ describe CdnetworksClient do
       end
     end
 
-    describe AuthOpenApi do
-      before { @fake_token, _, @fake_identifier = stub_auth_calls }
+    describe ConfigOpenApi do
+      it "fetches list using api key endpoint for OpenApiV2" do
+        expect(@cdn_api.list).to include(@fake_service)
 
+        expect(a_request(:post, "#{@url}/api/rest/getApiKeyList")).
+                 to have_been_made
+      end
+    end
+
+    describe AuthOpenApi do
       it "gets a session token" do
         session_token = @cdn_api.get_session_token
 
@@ -412,7 +421,6 @@ describe CdnetworksClient do
     end
 
     describe OpenApiKeys do
-      before { @fake_token, @fake_key, _, @fake_service = stub_auth_calls }
 
       it "gets api keys" do
         api_key = @cdn_api.get_api_key(@fake_token, @fake_service)
@@ -428,7 +436,6 @@ describe CdnetworksClient do
         let(:expected_bandwidth) { 1.23456 }
 
         before do
-          _, _, _, @fake_service = stub_auth_calls
           stub_get_edge_traffic(expected_bandwidth)
         end
 

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -384,7 +384,7 @@ describe CdnetworksClient do
       end
 
       it "doesn't infinite loop if session can't be re-established" do
-        stub_request(:post, "#{@url}/api/rest/login").to_return(body: JSON.pretty_unparse(loginResponse: {returnCode: 101}))
+        stub_request(:post, "#{@url}/api/rest/login").to_return(body: JSON.pretty_unparse(loginResponse: {resultCode: 101}))
         expect { @cdn_api.get_api_key_list(bad_token) }.to raise_error(OpenApiError::ApiError)
       end
 

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -355,4 +355,36 @@ describe CdnetworksClient do
     end
   end
 
+  context StatisticsOpenApi do
+    describe "#bandwidth_usage" do
+      let(:end_time)           { Time.now }
+      let(:start_time)         { end_time - 1*60*60*24 }
+      let(:expected_bandwidth) { 1.23456 }
+
+      before do
+        # TODO: extract stubs to a helper
+        fake_token = "12345sessiontoken"
+        fake_api_key = "anapikey56789"
+        stub_request(:post, "#{@url}/api/rest/login").
+          to_return body: JSON.pretty_unparse(loginResponse: {resultCode: 0,
+                                                             session: [fake_token, "svcGroup", "svcGroupIdentifier"]})
+
+        stub_request(:get, "#{@url}/api/rest/getApiKeyList?output=json&session_token=#{fake_token}").
+          to_return body: JSON.pretty_unparse(apiKeyListResponse: {apiKeyInformation:
+                                                                    [1, 'serviceName', fake_api_key, 'parentKey'],
+                                                                   resultCode: 0})
+        stub_request(:post, "https://openapi.us.cdnetworks.com/rest/traffic/edge").
+          to_return body: JSON.pretty_unparse(edgeTrafficResponse: {returnCode: 0,
+                                                                    trafficItem:
+                                                                      ['200809162305', expected_bandwidth, 10.10]})
+
+
+      end
+
+      it "returns bandwidth usage for a given time period" do
+        expect(@cdn_api.bandwidth_usage start_time, end_time).to eq expected_bandwidth
+      end
+    end
+  end
+
 end

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -21,25 +21,25 @@ describe CdnetworksClient do
     it "calls the list method of the cdnetworks api" do
       @cdn_api.list
 
-      a_request(:post, "#{@url}/config/rest/pan/site/list").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/list").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
     end
 
     it "includes options passed as a hash" do
       @cdn_api.list(:prod => true)
 
-      a_request(:post, "#{@url}/config/rest/pan/site/list").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/list").
         with(:body    => 'prod=true&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
     end
   end
 
@@ -52,25 +52,25 @@ describe CdnetworksClient do
     it "calls the view method of the cdnetworks api" do
       @cdn_api.view
 
-      a_request(:post, "#{@url}/config/rest/pan/site/view").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/view").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
 
     it "includes options passed as a hash" do
       @cdn_api.view(:pad => "cache.foo.com")
 
-      a_request(:post, "#{@url}/config/rest/pan/site/view").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/view").
         with(:body    => 'pad=cache.foo.com&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
 
   end
@@ -84,25 +84,25 @@ describe CdnetworksClient do
     it "calls the add method of the cdnetworks api" do
       @cdn_api.add
 
-      a_request(:post, "#{@url}/config/rest/pan/site/add").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/add").
       with(:body    => 'user=user%40user.com&pass=secret',
            :headers => {
                          'Accept'      =>'*/*',
                          'Content-Type'=>'application/x-www-form-urlencoded',
-                         'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                         'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
 
     it "includes options passed as a hash" do
       @cdn_api.add(:pad => "cache.foo.com", :origin => "neworigin.foo.com")
 
-      a_request(:post, "#{@url}/config/rest/pan/site/add").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/add").
         with(:body    => 'pad=cache.foo.com&origin=neworigin.foo.com&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
   end
 
@@ -115,25 +115,25 @@ describe CdnetworksClient do
     it "calls the edit method of the cdnetworks api" do
       @cdn_api.edit
 
-      a_request(:post, "#{@url}/config/rest/pan/site/edit").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/edit").
       with(:body    => 'user=user%40user.com&pass=secret',
            :headers => {
                          'Accept'      =>'*/*',
                          'Content-Type'=>'application/x-www-form-urlencoded',
-                         'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                         'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
 
     it "includes the options passed as a hash" do
       @cdn_api.edit(:pad => "cache.foo.com", :honor_byte_range => "1")
 
-      a_request(:post, "#{@url}/config/rest/pan/site/edit").
+      expect(a_request(:post, "#{@url}/config/rest/pan/site/edit").
       with(:body    => 'pad=cache.foo.com&honor_byte_range=1&user=user%40user.com&pass=secret',
            :headers => {
                          'Accept'      =>'*/*',
                          'Content-Type'=>'application/x-www-form-urlencoded',
-                         'User-Agent'  =>'Ruby'}).
-      should have_been_made
+                         'User-Agent'  =>'Ruby'})).
+      to have_been_made
     end
   end
 
@@ -147,37 +147,37 @@ describe CdnetworksClient do
       it "calls the purge method of the cdnetworks api" do
         @cdn_api.execute_cache_purge
 
-        a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
+        expect(a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
         with(:body    => 'userId=user%40user.com&password=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "includes the options passed as a hash" do
         @cdn_api.execute_cache_purge(:purgeUriList => "cdn.example.com")
 
-        a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
+        expect(a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
         with(:body    => 'purgeUriList=cdn.example.com&userId=user%40user.com&password=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "handles options passed as an array" do
         @cdn_api.execute_cache_purge(:purgeUriList => ["cdn.example.com", "pad.foo.com"])
 
-        a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
+        expect(a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/executeCachePurge").
         with(:body    => 'purgeUriList=cdn.example.com&purgeUriList=pad.foo.com&userId=user%40user.com&password=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
 
@@ -190,13 +190,13 @@ describe CdnetworksClient do
       it "calls the cache domain list method of the cdnetworks api" do
         @cdn_api.get_cache_domain_list
 
-        a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/getCacheDomainList").
+        expect(a_request(:post, "#{@url}/OpenAPI/services/CachePurgeAPI/getCacheDomainList").
         with(:body    => 'userId=user%40user.com&password=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
   end
@@ -211,36 +211,36 @@ describe CdnetworksClient do
       it "calls the purge method" do
         @cdn_api.do_purge
 
-        a_request(:post, "#{@url}/purge/rest/doPurge").
+        expect(a_request(:post, "#{@url}/purge/rest/doPurge").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "handles options passed as a hash" do
         @cdn_api.do_purge(:pad => "cdn.example.com", :type => "all")
 
-        a_request(:post, "#{@url}/purge/rest/doPurge").
+        expect(a_request(:post, "#{@url}/purge/rest/doPurge").
         with(:body    => 'pad=cdn.example.com&type=all&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "handles options passed as an array" do
         @cdn_api.do_purge(:path => ["/images/one.jpg", "/images/two.jpg"])
-        a_request(:post, "#{@url}/purge/rest/doPurge").
+        expect(a_request(:post, "#{@url}/purge/rest/doPurge").
         with(:body    => 'path=%2Fimages%2Fone.jpg&path=%2Fimages%2Ftwo.jpg&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
 
@@ -248,13 +248,13 @@ describe CdnetworksClient do
       it "calls the list method" do
         @cdn_api.pad_list
 
-        a_request(:post, "#{@url}/purge/rest/padList").
+        expect(a_request(:post, "#{@url}/purge/rest/padList").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
 
@@ -262,25 +262,25 @@ describe CdnetworksClient do
       it "calls the status method" do
         @cdn_api.status
 
-        a_request(:post, "#{@url}/purge/rest/status").
+        expect(a_request(:post, "#{@url}/purge/rest/status").
         with(:body    => 'user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
 
       it "handles options passsed as a hash" do
         @cdn_api.status(pid: 1234)
 
-        a_request(:post, "#{@url}/purge/rest/status").
+        expect(a_request(:post, "#{@url}/purge/rest/status").
         with(:body    => 'pid=1234&user=user%40user.com&pass=secret',
              :headers => {
                            'Accept'      =>'*/*',
                            'Content-Type'=>'application/x-www-form-urlencoded',
-                           'User-Agent'  =>'Ruby'}).
-        should have_been_made
+                           'User-Agent'  =>'Ruby'})).
+        to have_been_made
       end
     end
   end
@@ -288,7 +288,7 @@ describe CdnetworksClient do
   context "locations" do
     it "uses the US access domain by default" do
       request = @cdn_api.compose_request("/some/path",{})
-      request.path.should include("openapi.us.cdnetworks.com")
+      expect(request.path).to include("openapi.us.cdnetworks.com")
     end
 
     it "uses the Korean access domain when specified" do
@@ -299,7 +299,7 @@ describe CdnetworksClient do
                    )
 
       request = korean_cdn.compose_request("/some/path",{})
-      request.path.should include("openapi.kr.cdnetworks.com")
+      expect(request.path).to include("openapi.kr.cdnetworks.com")
     end
 
     it "uses the Japanese access domain when specified" do
@@ -310,7 +310,7 @@ describe CdnetworksClient do
                    )
 
       request = japanese_cdn.compose_request("/some/path",{})
-      request.path.should include("openapi.jp.cdnetworks.com")
+      expect(request.path).to include("openapi.jp.cdnetworks.com")
     end
 
     it "uses the Chinese access domain when specified" do
@@ -321,7 +321,7 @@ describe CdnetworksClient do
                    )
 
       request = chinese_cdn.compose_request("/some/path",{})
-      request.path.should include("openapi.txnetworks.cn")
+      expect(request.path).to include("openapi.txnetworks.cn")
     end
   end
 
@@ -339,8 +339,8 @@ describe CdnetworksClient do
 
     it "returns an error" do
       error_result = @cdn_api.list
-      error_result.should include("An error has occurred")
-      error_result.should include("execution expired")
+      expect(error_result).to include("An error has occurred")
+      expect(error_result).to include("execution expired")
     end
   end
 

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -407,6 +407,8 @@ describe CdnetworksClient do
 
     describe AuthOpenApi do
       it "raises error on failed login" do
+        stub_failed_login
+        expect{ @cdn_api.get_session_token }.to raise_error(OpenApiError::ApiError)
       end
 
       it "gets a session token" do

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -425,7 +425,6 @@ describe CdnetworksClient do
     end
 
     describe OpenApiKeys do
-
       it "gets api keys" do
         api_key = @cdn_api.get_api_key(@fake_token, @fake_service)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,39 @@
 require 'webmock/rspec'
 
 require File.expand_path('../../lib/cdnetworks-client.rb', __FILE__)
+
+module ApiStubs
+  def stub_auth_calls
+    fake_token = "12345sessiontoken"
+    fake_api_key = "anapikey56789"
+    stub_login(fake_token)
+    stub_get_api_keys(fake_token, fake_api_key)
+
+    [fake_token, fake_api_key]
+  end
+
+  def stub_login(return_token)
+    stub_request(:post, "#{@url}/api/rest/login").
+      to_return body: JSON.pretty_unparse(loginResponse: {resultCode: 0,
+                                                          session: [return_token, "svcGroup", "svcGroupIdentifier"]})
+  end
+
+  def stub_get_api_keys(session_token, return_key)
+    stub_request(:get, "#{@url}/api/rest/getApiKeyList?output=json&session_token=#{session_token}").
+    to_return body: JSON.pretty_unparse(apiKeyListResponse: {apiKeyInformation:
+                                                             [1, 'serviceName', return_key, 'parentKey'],
+                                                             resultCode: 0})
+  end
+
+  def stub_get_edge_traffic(expected_bandwidth)
+    # TODO - take date as input and strftime it in output
+    stub_request(:post, "https://openapi.us.cdnetworks.com/rest/traffic/edge").
+      to_return body: JSON.pretty_unparse(edgeTrafficResponse: {returnCode: 0,
+                                                                trafficItem:
+                                                                ['200809162305', expected_bandwidth, 10.10]})
+  end
+end
+
+RSpec.configure do |config|
+  config.include ApiStubs
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,13 +4,14 @@ require File.expand_path('../../lib/cdnetworks-client.rb', __FILE__)
 
 module ApiStubs
   def stub_auth_calls
-    fake_token = "12345sessiontoken"
+    fake_token = "12345thetoken"
     fake_api_key = "EAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     fake_identifier = "90525E70B7842930586545C6F1C9310C"
+    fake_service_name = 'cdn.example-app.host.com'
     stub_login(fake_token, fake_identifier)
-    stub_get_api_keys(fake_token, fake_api_key)
+    stub_get_api_keys(fake_token, fake_service_name, fake_api_key)
 
-    [fake_token, fake_api_key, fake_identifier]
+    [fake_token, fake_api_key, fake_identifier, fake_service_name]
   end
 
   def stub_login(return_token, svc_identifier)
@@ -22,14 +23,14 @@ module ApiStubs
     stub_request(:post, "#{@url}/api/rest/login").to_return(body: resp)
   end
 
-  def stub_get_api_keys(session_token, return_key)
+  def stub_get_api_keys(session_token, service_name, return_key)
     resp = JSON.pretty_unparse({apiKeyInfo: {returnCode: 0,
                                              apiKeyInfoItem: [{type: 0,
                                                                serviceName: "Content Acceleration",
                                                                apiKey: "SERVICECATEGORY_CA",
                                                                parentApiKey: "SERVICECATEGORY_CA"},
                                                                {type: 1,
-                                                                serviceName: "cdn.example-app.1234.host.com",
+                                                                serviceName: service_name,
                                                                 apiKey: return_key,
                                                                 parentApiKey: "SERVICECATEGORY_CA"},
                                                                 {type: 1,
@@ -37,7 +38,7 @@ module ApiStubs
                                                                  apiKey: "55555555555555555555555555555555",
                                                                  parentApiKey: "SERVICECATEGORY_CA"}]}})
 
-    stub_request(:get, "#{@url}/api/rest/getApiKeyList?output=json&session_token=#{session_token}").to_return(body: resp)
+    stub_request(:get, "#{@url}/api/rest/getApiKeyList?output=json&sessionToken=#{session_token}").to_return(body: resp)
   end
 
   def stub_get_edge_traffic(expected_bandwidth)
@@ -45,7 +46,7 @@ module ApiStubs
     resp = JSON.pretty_unparse(trafficResponse: {returnCode: 0,
                                                  trafficItem:
                                                  [{dateTime: '200809162305', bandwidth: expected_bandwidth, dataTransferred: 10.10}]})
-    stub_request(:post, "https://openapi.us.cdnetworks.com/rest/traffic/edge").to_return(body: resp)
+    stub_request(:post, "#{@url}/rest/traffic/edge").to_return(body: resp)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,19 @@ module ApiStubs
                                                  [{dateTime: '200809162305', bandwidth: 10, dataTransferred: expected_bandwidth}]})
     stub_request(:post, "#{@url}/api/rest/traffic/edge").to_return(body: resp)
   end
+
+  def stub_pad_list(expected_service)
+     resp = { "PadConfigResponse" => {
+                "resultCode" => 200,
+                "data"=> {
+                  "errors" => "",
+                  "data" => [ {"origin"=>expected_service, "pad"=>"pad.#{expected_service}", "id"=>11111},
+                              {"origin"=>"another-site.com", "pad"=>"assets.another-site.com", "id"=>22222},
+                              {"origin"=>"some.site.with.many.subdomains.com", "pad"=>"assets.many.subdomains.com", "id"=>33333},
+                              {"origin"=>"somesite.s3.amazonaws.com", "pad"=>"assets.somesite.com", "id"=>44444} ]}}}
+
+    stub_request(:post, "#{@url}/api/rest/pan/site/list").to_return(body: JSON.pretty_unparse(resp))
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ module ApiStubs
   end
 
   def stub_login(return_token, svc_identifier)
-    resp = JSON.pretty_unparse({loginResponse: {resultCode: 0,
+    resp = JSON.pretty_unparse({loginResponse: {returnCode: 0,
                                                 session: [{sessionToken: return_token,
                                                            svcGroupName: "Service Group Name",
                                                            svcGroupIdentifier: svc_identifier}]}})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,32 +5,47 @@ require File.expand_path('../../lib/cdnetworks-client.rb', __FILE__)
 module ApiStubs
   def stub_auth_calls
     fake_token = "12345sessiontoken"
-    fake_api_key = "anapikey56789"
-    stub_login(fake_token)
+    fake_api_key = "EAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    fake_identifier = "90525E70B7842930586545C6F1C9310C"
+    stub_login(fake_token, fake_identifier)
     stub_get_api_keys(fake_token, fake_api_key)
 
-    [fake_token, fake_api_key]
+    [fake_token, fake_api_key, fake_identifier]
   end
 
-  def stub_login(return_token)
-    stub_request(:post, "#{@url}/api/rest/login").
-      to_return body: JSON.pretty_unparse(loginResponse: {resultCode: 0,
-                                                          session: [return_token, "svcGroup", "svcGroupIdentifier"]})
+  def stub_login(return_token, svc_identifier)
+    resp = JSON.pretty_unparse({loginResponse: {resultCode: 0,
+                                                session: [{sessionToken: return_token,
+                                                           svcGroupName: "Service Group Name",
+                                                           svcGroupIdentifier: svc_identifier}]}})
+
+    stub_request(:post, "#{@url}/api/rest/login").to_return(body: resp)
   end
 
   def stub_get_api_keys(session_token, return_key)
-    stub_request(:get, "#{@url}/api/rest/getApiKeyList?output=json&session_token=#{session_token}").
-    to_return body: JSON.pretty_unparse(apiKeyListResponse: {apiKeyInformation:
-                                                             [1, 'serviceName', return_key, 'parentKey'],
-                                                             resultCode: 0})
+    resp = JSON.pretty_unparse({apiKeyInfo: {returnCode: 0,
+                                             apiKeyInfoItem: [{type: 0,
+                                                               serviceName: "Content Acceleration",
+                                                               apiKey: "SERVICECATEGORY_CA",
+                                                               parentApiKey: "SERVICECATEGORY_CA"},
+                                                               {type: 1,
+                                                                serviceName: "cdn.example-app.1234.host.com",
+                                                                apiKey: return_key,
+                                                                parentApiKey: "SERVICECATEGORY_CA"},
+                                                                {type: 1,
+                                                                 serviceName: "cdn.another.app.com",
+                                                                 apiKey: "55555555555555555555555555555555",
+                                                                 parentApiKey: "SERVICECATEGORY_CA"}]}})
+
+    stub_request(:get, "#{@url}/api/rest/getApiKeyList?output=json&session_token=#{session_token}").to_return(body: resp)
   end
 
   def stub_get_edge_traffic(expected_bandwidth)
     # TODO - take date as input and strftime it in output
-    stub_request(:post, "https://openapi.us.cdnetworks.com/rest/traffic/edge").
-      to_return body: JSON.pretty_unparse(edgeTrafficResponse: {returnCode: 0,
-                                                                trafficItem:
-                                                                ['200809162305', expected_bandwidth, 10.10]})
+    resp = JSON.pretty_unparse(trafficResponse: {returnCode: 0,
+                                                 trafficItem:
+                                                 ['200809162305', expected_bandwidth, 10.10]})
+    stub_request(:post, "https://openapi.us.cdnetworks.com/rest/traffic/edge").to_return(body: resp)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ module ApiStubs
     resp = JSON.pretty_unparse(trafficResponse: {returnCode: 0,
                                                  trafficItem:
                                                  [{dateTime: '200809162305', bandwidth: expected_bandwidth, dataTransferred: 10.10}]})
-    stub_request(:post, "#{@url}/rest/traffic/edge").to_return(body: resp)
+    stub_request(:post, "#{@url}/api/rest/traffic/edge").to_return(body: resp)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ module ApiStubs
     # TODO - take date as input and strftime it in output
     resp = JSON.pretty_unparse(trafficResponse: {returnCode: 0,
                                                  trafficItem:
-                                                 ['200809162305', expected_bandwidth, 10.10]})
+                                                 [{dateTime: '200809162305', bandwidth: expected_bandwidth, dataTransferred: 10.10}]})
     stub_request(:post, "https://openapi.us.cdnetworks.com/rest/traffic/edge").to_return(body: resp)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ module ApiStubs
     # TODO - take date as input and strftime it in output
     resp = JSON.pretty_unparse(trafficResponse: {returnCode: 0,
                                                  trafficItem:
-                                                 [{dateTime: '200809162305', bandwidth: expected_bandwidth, dataTransferred: 10.10}]})
+                                                 [{dateTime: '200809162305', bandwidth: 10, dataTransferred: expected_bandwidth}]})
     stub_request(:post, "#{@url}/api/rest/traffic/edge").to_return(body: resp)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ module ApiStubs
                                                                  apiKey: "55555555555555555555555555555555",
                                                                  parentApiKey: "SERVICECATEGORY_CA"}]}})
 
-    stub_request(:get, "#{@url}/api/rest/getApiKeyList?output=json&sessionToken=#{session_token}").to_return(body: resp)
+    stub_request(:post, "#{@url}/api/rest/getApiKeyList").with(body: {"output"=>"json", "sessionToken"=>session_token}).to_return(body: resp)
   end
 
   def stub_get_edge_traffic(expected_bandwidth)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,10 @@ module ApiStubs
     stub_request(:post, "#{@url}/api/rest/login").to_return(body: resp)
   end
 
+  def stub_failed_login
+    stub_request(:post, "#{@url}/api/rest/login").to_return(body: JSON.pretty_unparse(loginResponse: {returnCode: 101}))
+  end
+
   def stub_get_api_keys(session_token, service_name, return_key)
     resp = JSON.pretty_unparse({apiKeyInfo: {returnCode: 0,
                                              apiKeyInfoItem: [{type: 0,


### PR DESCRIPTION
This PR provides a wrapping function for the OpenAPI v2 statistics "edge traffic" endpoint for determining bandwidth usage.

To get this working, I also had to build in support for the new session based login system in OpenAPI v2, and the method of fetching and using API keys during a given session. These are working and tested, but may need some revision and robustness refactoring as they include a few hacks intended to avoid changing the gem's interface and basic behaviors too much.