### PR TITLE
Return 0 for bandwidth usage when cdnetworks returns '404 there is no data'

### DIFF
--- a/lib/cdnetworks-client/statistics_open_api.rb
+++ b/lib/cdnetworks-client/statistics_open_api.rb
@@ -21,7 +21,7 @@ module StatisticsOpenApi
     response = call(BANDWIDTH_PATH, opts)
 
     if response[:code].to_s == "404"
-      nil
+      0.0
     else
       Array.wrap(response[:body]['trafficResponse']['trafficItem']).map{|i| i['dataTransferred']}.inject(&:+)
     end

--- a/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
+++ b/spec/lib/cdnetworks-client/cdnetworks_client_spec.rb
@@ -445,6 +445,13 @@ describe CdnetworksClient do
         it "returns bandwidth usage for a given time period" do
           expect(@cdn_api.bandwidth_usage @fake_service, start_time, end_time).to eq expected_bandwidth
         end
+
+        it "returns 0 for service with no traffic in given range (cdnetworks returns 404)" do
+          resp = JSON.pretty_unparse(trafficResponse: {returnCode: 404})
+          stub_request(:post, "#{@url}/api/rest/traffic/edge").to_return(body: resp)
+
+          expect(@cdn_api.bandwidth_usage @fake_service, start_time, end_time).to eq(0)
+        end
       end
     end
 


### PR DESCRIPTION
CDNetworks OpenAPI returns "404" when there is no traffic data for a given PAD. Previously this returned `nil`, but since returning `nil` was used by the old (non OpenApi) code to indicate that an error occurred, this was causing errors in applications which expected a non-nil response from the `CdnetworksClient#bandwidth_usage` method.